### PR TITLE
S-499: Updating pom to pull the cheri version of JCTools

### DIFF
--- a/common/local-maven-repo/pom.xml
+++ b/common/local-maven-repo/pom.xml
@@ -1,6 +1,0 @@
-<repositories>
-  <repository>
-    <id>local-maven-repo</id>
-    <url>file:///${project.basedir}/common/local-maven-repo</url>
-  </repository>
-</repositories>

--- a/common/local-maven-repo/pom.xml
+++ b/common/local-maven-repo/pom.xml
@@ -1,0 +1,6 @@
+<repositories>
+  <repository>
+    <id>local-maven-repo</id>
+    <url>file:///${project.basedir}/common/local-maven-repo</url>
+  </repository>
+</repositories>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
+      <version>4.0.2-SNAPSHOT-CHERI</version>
       <!-- Need compile scope to be taken into account by shade plugin -->
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
## Motivation
Netty needs to pull the ported version of `JCTools`
## Changes
Updated `pom.xml` to pull the CHERI version of the JCTools jar.
